### PR TITLE
Fixed incorrect meta overwrite

### DIFF
--- a/Listener/LoggableListener.php
+++ b/Listener/LoggableListener.php
@@ -92,9 +92,9 @@ class LoggableListener extends BaseListener
                 // save relations to parent entity
                 if ($object instanceof LoggableChildInterface && $object->getParentEntity() !== null) {
                     $parent = $object->getParentEntity();
-                    $meta = AbstractWrapper::wrap($parent, $om)->getMetadata();
+                    $parentMeta = AbstractWrapper::wrap($parent, $om)->getMetadata();
                     $logEntry->setParentId($parent->getId());
-                    $logEntry->setParentClass($meta->name);
+                    $logEntry->setParentClass($parentMeta->name);
                 }
 
                 // don't save old data for new entity,


### PR DESCRIPTION
This PR fixes the issue that the isSingleValuedAssociation method  (line 118) is called on the wrong meta class when a parent entity is configured
