### PR TITLE
"Column 'name' cannot be null" on create

### DIFF
--- a/Entity/MappedSuperclass/AbstractLogEntry.php
+++ b/Entity/MappedSuperclass/AbstractLogEntry.php
@@ -34,7 +34,7 @@ abstract class AbstractLogEntry extends GedmoEntry implements LogEntryInterface,
 
     /**
      * @var string
-     * @ORM\Column(type="string", length=255, nullable=false)
+     * @ORM\Column(type="string", length=255, nullable=true)
      */
     protected $name;
 


### PR DESCRIPTION
When we are in the create context for a new log entry, we get an error of type integrity constraint where the 'name' column cannot be null.
Setting nullable to true for the $name property did the trick.